### PR TITLE
use a `DoFn` to bundle items together

### DIFF
--- a/stac_recipes/writers/pgstac.py
+++ b/stac_recipes/writers/pgstac.py
@@ -7,7 +7,9 @@ from pypgstac.load import Loader
 ItemType = tuple[str, pystac.STACObject]
 
 
-def store_to_pgstac(objs: ItemType | Sequence[ItemType], *, type_, method, options):
+def store_to_pgstac(
+    objs: ItemType | Sequence[ItemType], *, type_, method, client: PgstacDB
+):
     if not isinstance(objs, list):
         objs = [objs]
 
@@ -15,8 +17,7 @@ def store_to_pgstac(objs: ItemType | Sequence[ItemType], *, type_, method, optio
         obj.to_dict() if isinstance(obj, pystac.STACObject) else obj for _, obj in objs
     ]
 
-    db = PgstacDB(**options)
-    loader = Loader(db)
+    loader = Loader(client)
 
     if type_ == "collection":
         loader.load_collections(mappings, insert_mode=method)


### PR DESCRIPTION
- [x] closes #22

As it turns out, bundling / chunking the items is not optional but required, since otherwise the database will start refusing connections (this may also be caused by `store_to_pgstac` not explicitly closing the database client, not sure).

By using a `DoFn`, we can use its `setup` / `teardown` methods to reuse the database connection, and `start_bundle` / `finish_bundle` to implement the chunking.